### PR TITLE
Remove "go vet" as it is now replaced with golangci-lint

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -7,7 +7,7 @@
     [
       "exec",
       {
-        "afterVersion": "RELEASE_TAG=`git describe --tags --abbrev=0` make package-lite"
+        "afterVersion": "RELEASE_TAG=`git describe --tags --abbrev=0` make package"
       }
     ],
     [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
       - image: cimg/go:1.13
     steps:
       - checkout
+      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
       - run: curl -vkL -o - https://github.com/intuit/auto/releases/download/v9.21.0/auto-linux.gz | gunzip > ~/auto
       - run: chmod a+x ~/auto
       - run: ~/auto shipit

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ REPLAYOSX := ./bin/replay-zero-osx
 REPLAYWIN := ./bin/replay-zero.exe
 
 .PHONY: all
-all: clean vet lint $(REPLAY) $(REPLAYOSX) $(REPLAYWIN) test
+all: clean lint $(REPLAY) $(REPLAYOSX) $(REPLAYWIN) test
 
 $(REPLAY):
 	GOOS=linux go build -mod=vendor $(GO_LDFLAGS) $(BUILDARGS) -o $@ .
@@ -28,19 +28,13 @@ vendor:
 	go mod tidy
 	go mod vendor
 
-.PHONY: test
-test:
-	go test -mod=vendor -timeout=30s $(TESTARGS) ./...
-	@$(MAKE) vet
-	@if [ -z "${CODEBUILD_BUILD_ID}" ]; then $(MAKE) lint; fi
-
-.PHONY: vet
-vet:
-	go vet -mod=vendor $(VETARGS) ./...
-
 .PHONY: lint
 lint:
 	@ golangci-lint run --fast
+
+.PHONY: test
+test:
+	go test -mod=vendor -timeout=30s $(TESTARGS) ./...
 
 .PHONY: cover
 cover:
@@ -54,15 +48,6 @@ clean:
 
 .PHONY: package
 package: all
-	zip -j bin/replay-zero.zip $(REPLAY)
-	zip -j bin/replay-zero-osx.zip $(REPLAYOSX)
-	zip -j bin/replay-zero-win.zip $(REPLAYWIN)
-	shasum -a 256 bin/replay-zero.zip > bin/replay-zero.sha256
-	shasum -a 256 bin/replay-zero-osx.zip > bin/replay-zero-osx.sha256
-	shasum -a 256 bin/replay-zero-win.zip > bin/replay-zero-win.sha256
-
-.PHONY: package-lite
-package: $(REPLAY) $(REPLAYOSX) $(REPLAYWIN)
 	zip -j bin/replay-zero.zip $(REPLAY)
 	zip -j bin/replay-zero-osx.zip $(REPLAYOSX)
 	zip -j bin/replay-zero-win.zip $(REPLAYWIN)


### PR DESCRIPTION
<!-- Thank you for contributing this pull request!

Please make the PR against the `master` branch, add a description of what's changing, and link any relevant issues or PRs. -->

## What's changing

Remove obsolete references to `go vet` and AWS Codebuild

## What else might be impacted?

...

## Checklist

[ ] Unit tests (updated and/or added)
[ ] Documentation (function/class docs, comments, etc.)
