### PR TITLE
Add log levels for Kinesis client

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -173,6 +173,6 @@ func (c *kinesisWrapper) sendToStream(message interface{}, stream string) error 
 	if err != nil {
 		return err
 	}
-	c.logger("%+v\n", response)
+	c.logger("Successfully put record to stream=%s\n%+v\n", stream, response)
 	return nil
 }

--- a/kinesis.go
+++ b/kinesis.go
@@ -72,8 +72,9 @@ func buildKinesisClient(streamName, streamRole string, logFunc func(string, ...i
 
 	sseEnabled, err := streamHasSSE(streamName, kinesisHandle)
 	if err != nil {
-		logFunc("Could not determine if SSE is enabled for stream %s: %s", streamName, err)
-	} else if !sseEnabled {
+		logFunc(err.Error())
+	}
+	if !sseEnabled {
 		logWarn(fmt.Sprintf("Kinesis stream %s does NOT have Server-Side Encryption (SSE) enabled", streamName))
 	}
 	return &kinesisWrapper{
@@ -86,6 +87,10 @@ func streamHasSSE(streamName string, client kinesisiface.KinesisAPI) (bool, erro
 	streamInfo, err := client.DescribeStream(&kinesis.DescribeStreamInput{
 		StreamName: aws.String(streamName),
 	})
+	if streamInfo == nil || streamInfo.StreamDescription == nil {
+		return false, fmt.Errorf("Could not determine if SSE is enabled for stream %s: %w", streamName, err)
+	}
+
 	return *streamInfo.StreamDescription.EncryptionType == kinesis.EncryptionTypeKms, err
 }
 

--- a/kinesis.go
+++ b/kinesis.go
@@ -54,15 +54,15 @@ func buildClient(streamName, streamRole string, logFunc func(string, ...interfac
 // Uses STS to assume an IAM role for credentials to write records
 // to a real Kinesis stream in AWS
 func buildKinesisClient(streamName, streamRole string, logFunc func(string, ...interface{})) *kinesisWrapper {
-	log.Printf("Creating AWS Kinesis client")
+	logFunc("Creating AWS Kinesis client (stream=%s)", streamName)
 	userSession := session.Must(session.NewSession(&aws.Config{
 		CredentialsChainVerboseErrors: aws.Bool(verboseCredentialErrors),
 		Region:                        aws.String(getRegion()),
 	}))
 
-	log.Println("Fetching temp credentials...")
+	logFunc("Fetching temp credentials...")
 	kinesisTempCreds := stscreds.NewCredentials(userSession, streamRole)
-	log.Println("Success!")
+	logFunc("Success!")
 
 	kinesisHandle := kinesis.New(userSession, &aws.Config{
 		CredentialsChainVerboseErrors: aws.Bool(verboseCredentialErrors),
@@ -75,7 +75,7 @@ func buildKinesisClient(streamName, streamRole string, logFunc func(string, ...i
 		logFunc(err.Error())
 	}
 	if !sseEnabled {
-		logWarn(fmt.Sprintf("Kinesis stream %s does NOT have Server-Side Encryption (SSE) enabled", streamName))
+		logWarn(fmt.Sprintf("Kinesis stream '%s' does NOT have Server-Side Encryption (SSE) enabled", streamName))
 	}
 	return &kinesisWrapper{
 		client: kinesisHandle,

--- a/kinesis_test.go
+++ b/kinesis_test.go
@@ -45,6 +45,26 @@ func TestGetRegionOverride(t *testing.T) {
 	}
 }
 
+func TestStreamHasSSEError(t *testing.T) {
+	mockKinesis := &mockKinesisClient{}
+
+	hasSSE, err := streamHasSSE("simulate_empty_response", mockKinesis)
+	if err == nil {
+		t.Errorf("Expected error, but got <nil>")
+	}
+	if hasSSE {
+		t.Errorf("Expected 'hasSSE' == FALSE, but was TRUE")
+	}
+
+	hasSSE, err = streamHasSSE("success", mockKinesis)
+	if err != nil {
+		t.Errorf("Expected no error, but got %s", err)
+	}
+	if !hasSSE {
+		t.Errorf("Expected 'hasSSE' == TRUE, but was FALSE")
+	}
+}
+
 func TestBuildMessages(t *testing.T) {
 	expected := EventChunk{
 		ChunkNumber: 0,

--- a/kinesis_test.go
+++ b/kinesis_test.go
@@ -65,9 +65,10 @@ func TestBuildMessages(t *testing.T) {
 
 func TestSendToStreamMarshalError(t *testing.T) {
 	mockKinesis := &mockKinesisClient{}
+	wrapper := &kinesisWrapper{client: mockKinesis}
 
 	// json.Marshal can't Marshal certain types, like channels
-	err := sendToStream(make(chan int), "test", mockKinesis)
+	err := wrapper.sendToStream(make(chan int), "test")
 	if mockKinesis.timesCalled > 0 {
 		t.Error("Expected mock Kinesis client not to be called, but it was")
 	}
@@ -78,8 +79,9 @@ func TestSendToStreamMarshalError(t *testing.T) {
 
 func TestSendToStreamKinesisError(t *testing.T) {
 	mockKinesis := &mockKinesisClient{}
+	wrapper := &kinesisWrapper{client: mockKinesis}
 
-	err := sendToStream(`{"data": "test"}`, "simulate_error", mockKinesis)
+	err := wrapper.sendToStream(`{"data": "test"}`, "simulate_error")
 	if mockKinesis.timesCalled == 0 {
 		t.Error("Expected mock Kinesis client to be called, but it was NOT")
 	}
@@ -90,8 +92,12 @@ func TestSendToStreamKinesisError(t *testing.T) {
 
 func TestSendToStreamKinesisSuccess(t *testing.T) {
 	mockKinesis := &mockKinesisClient{}
+	wrapper := &kinesisWrapper{
+		client: mockKinesis,
+		logger: nopLog,
+	}
 
-	err := sendToStream(`{"data": "test"}`, "test", mockKinesis)
+	err := wrapper.sendToStream(`{"data": "test"}`, "test")
 	if mockKinesis.timesCalled == 0 {
 		t.Error("Expected mock Kinesis client to be called, but it was NOT")
 	}

--- a/main.go
+++ b/main.go
@@ -54,12 +54,20 @@ func logErr(err error) {
 }
 
 func logWarn(msg string, v ...interface{}) {
-	log.Printf("[WARN] "+msg+"\n", v)
+	if len(v) > 0 {
+		log.Printf("[WARN] "+msg+"\n", v)
+	} else {
+		log.Printf("[WARN] " + msg + "\n")
+	}
 }
 
 func logDebug(msg string, v ...interface{}) {
 	if flags.debug {
-		log.Printf("[DEBUG] "+msg+"\n", v)
+		if len(v) > 0 {
+			log.Printf("[DEBUG] "+msg+"\n", v)
+		} else {
+			log.Printf("[DEBUG] " + msg + "\n")
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -74,6 +74,10 @@ func logDebug(msg string, v ...interface{}) {
 func readFlags() {
 	// Overrides the default message of "pflag: help requested" in the case of -h / --help
 	flag.ErrHelp = errors.New("")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of replay-zero:\n")
+		flag.PrintDefaults()
+	}
 	flag.BoolVarP(&flags.version, "version", "V", false, "Print version info and exit")
 	flag.IntVarP(&flags.listenPort, "listen-port", "l", 9000, "The port the Replay Zero proxy will listen on")
 	flag.IntVarP(&flags.defaultTargetPort, "target-port", "t", 8080, "The port the Replay Zero proxy will forward to on localhost")
@@ -189,9 +193,9 @@ func createServerHandler(h eventHandler) func(http.ResponseWriter, *http.Request
 }
 
 func main() {
+	readFlags()
 	telemetry = getTelemetryAgent()
 	go telemetry.logUsage(telemetryUsageOpen)
-	readFlags()
 
 	var h eventHandler
 	if len(flags.streamName) > 0 {

--- a/main.go
+++ b/main.go
@@ -55,7 +55,8 @@ func logErr(err error) {
 
 func logWarn(msg string, v ...interface{}) {
 	if len(v) > 0 {
-		log.Printf("[WARN] "+msg+"\n", v)
+		println(msg)
+		log.Printf("[WARN] "+msg+"\n", v...)
 	} else {
 		log.Printf("[WARN] " + msg + "\n")
 	}
@@ -64,7 +65,7 @@ func logWarn(msg string, v ...interface{}) {
 func logDebug(msg string, v ...interface{}) {
 	if flags.debug {
 		if len(v) > 0 {
-			log.Printf("[DEBUG] "+msg+"\n", v)
+			log.Printf("[DEBUG] "+msg+"\n", v...)
 		} else {
 			log.Printf("[DEBUG] " + msg + "\n")
 		}

--- a/main.go
+++ b/main.go
@@ -53,15 +53,13 @@ func logErr(err error) {
 	}
 }
 
-func logWarn(msg string) {
-	if flags.debug {
-		log.Printf("[WARN] %s\n", msg)
-	}
+func logWarn(msg string, v ...interface{}) {
+	log.Printf("[WARN] "+msg+"\n", v)
 }
 
-func logDebug(msg string) {
+func logDebug(msg string, v ...interface{}) {
 	if flags.debug {
-		log.Printf("[DEBUG] %s\n", msg)
+		log.Printf("[WARN] "+msg+"\n", v)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func logWarn(msg string, v ...interface{}) {
 
 func logDebug(msg string, v ...interface{}) {
 	if flags.debug {
-		log.Printf("[WARN] "+msg+"\n", v)
+		log.Printf("[DEBUG] "+msg+"\n", v)
 	}
 }
 

--- a/offline_test.go
+++ b/offline_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	telemetry = &noopTelemetryAgent{}
+	telemetry = &nopTelemetryAgent{}
 }
 
 func TestOfflineHandleEventNoFlush(t *testing.T) {

--- a/online_test.go
+++ b/online_test.go
@@ -9,7 +9,7 @@ import (
 // - - - - - - - - - - - - -
 
 func init() {
-	telemetry = &noopTelemetryAgent{}
+	telemetry = &nopTelemetryAgent{}
 }
 
 // - - - - - - - - - - - - -
@@ -18,9 +18,10 @@ func init() {
 
 func TestHandleEvent(t *testing.T) {
 	mockKinesis := &mockKinesisClient{}
+	wrapper := &kinesisWrapper{client: mockKinesis, logger: nopLog}
 	testHandler := &onlineHandler{
 		kinesisStreamName: "test",
-		client:            mockKinesis,
+		kinesisHandle:     wrapper,
 	}
 
 	onlineSampleEvent := generateSampleEvent()

--- a/testUtils.go
+++ b/testUtils.go
@@ -58,12 +58,26 @@ type mockKinesisClient struct {
 	kinesisiface.KinesisAPI
 }
 
+func (m *mockKinesisClient) DescribeStream(inp *kinesis.DescribeStreamInput) (*kinesis.DescribeStreamOutput, error) {
+	m.timesCalled++
+	if *inp.StreamName == "simulate_empty_response" {
+		return &kinesis.DescribeStreamOutput{}, nil
+	} else {
+		return &kinesis.DescribeStreamOutput{
+			StreamDescription: &kinesis.StreamDescription{
+				StreamName:     aws.String("test-stream"),
+				EncryptionType: aws.String(kinesis.EncryptionTypeKms),
+			},
+		}, nil
+	}
+}
+
 func (m *mockKinesisClient) PutRecord(inp *kinesis.PutRecordInput) (*kinesis.PutRecordOutput, error) {
 	m.timesCalled++
 	// Used to deterministically simulate an error in the AWS SDK
 	// See `TestSendToStreamKinesisError` for usage
 	if *inp.StreamName == "simulate_error" {
-		return &kinesis.PutRecordOutput{}, fmt.Errorf("simulated error")
+		return &kinesis.PutRecordOutput{}, fmt.Errorf("simulated service error")
 	}
 	return &kinesis.PutRecordOutput{
 		SequenceNumber: aws.String("a"),

--- a/testUtils.go
+++ b/testUtils.go
@@ -80,3 +80,6 @@ func (m *mockKinesisClient) PutRecord(inp *kinesis.PutRecordInput) (*kinesis.Put
 func emptyWriter(h *offlineHandler) io.Writer {
 	return ioutil.Discard
 }
+
+// Accepts a log message and does nothing with it
+func nopLog(msg string, v ...interface{}) {}


### PR DESCRIPTION
<!-- Thank you for contributing this pull request!

Please make the PR against the `master` branch, add a description of what's changing, and link any relevant issues or PRs. -->

## What's changing

Previously, all log messages in the Kinesis code were shown at essentially INFO level.

Now that the same Kinesis code is used for both sending recorded HTTP data + telemetry messages, different Kinesis clients should be able to log messages at different levels.
For this purpose a `kinesisWrapper` struct now contains
```
type kinesisWrapper struct {
	client kinesisiface.KinesisAPI
	logger func(string, ...interface{})
}
```

The `logger` func can then log in the appropriate way for all subsequent use.

## What else might be impacted?

Also improved handling of the `DescribeStream` response to check if a stream has SSE enabled

## Checklist

[x] Unit tests (updated and/or added)
[x] Documentation (function/class docs, comments, etc.)
